### PR TITLE
Travis CI deployment to GitHub Pages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,4 @@ pom.xml
 .nrepl-port
 .cljs_rhino_repl
 .lein-failures
-/resources/public/js/testable.js
 /node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ before_script:
   - npm install
   - export PATH="$PATH:$(pwd)/node_modules/karma-cli/bin"
 script: lein doo chrome-headless test once
+before_deploy:
+  - rm -rf resources/public/js/compiled
+  - lein cljsbuild once min
 deploy:
   provider: pages
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ deploy:
   provider: pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+  local_dir: resources/public
   on:
     branch: travis-ci-deployment

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,9 @@ before_script:
   - npm install
   - export PATH="$PATH:$(pwd)/node_modules/karma-cli/bin"
 script: lein doo chrome-headless test once
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+  on:
+    branch: travis-ci-deployment

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ deploy:
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
   local_dir: resources/public
   on:
-    branch: travis-ci-deployment
+    branch: master

--- a/project.clj
+++ b/project.clj
@@ -51,8 +51,8 @@
                            :pretty-print false}}
                {:id "test"
                 :source-paths ["src" "test"]
-                :compiler {:output-to "resources/public/js/testable.js"
-                           :output-dir "resources/public/js/test"
+                :compiler {:output-to "resources/public/js/compiled/testable.js"
+                           :output-dir "resources/public/js/compiled/test"
                            :main "edsger.test-runner"
                            :optimizations :none}}]}
 


### PR DESCRIPTION
This PR makes changes to the Travis-CI config so that whenever we build succeeds on the `master` branch, the ClojureScript is compiled and the outputs are pushed to the `gh-pages` branch on this repository. The site can then be visited at site at http://umm-csci.github.io/edsger/.

Note that the code running at that URL now does not match what is in `master` because of my experiments, and it won't match until these commits make it to master.

