### PR TITLE
Improve precedence support

### DIFF
--- a/src/edsger/parsing.cljs
+++ b/src/edsger/parsing.cljs
@@ -3,7 +3,10 @@
   (:require [instaparse.core :as insta :refer-macros [defparser]]))
 
 ;; A simple CFG for parsing logical expressions containing several logic
-;; operators. Currently requires expressions to be fully parenthesized.
+;; operators. The parser is aware of presence, but some operators have
+;; equal presence, e.g. "p ≡ q ≡ r" needs to be parenthesized as
+;; "(p ≡ q) ≡ r" or as "p ≡ (q ≡ r)".
+
 (insta/defparser
   infix-cfg
   (str "top-level      = equiv-expr

--- a/src/edsger/parsing.cljs
+++ b/src/edsger/parsing.cljs
@@ -10,7 +10,7 @@
         <equiv-expr>   = implies-expr | equiv
         equiv          = <w> implies-expr <w '≡' w> implies-expr <w>
         <implies-expr> = and-or-expr | implies
-        implies        = <w> implies-expr <w '⇒' w> and-or-expr <w>
+        implies        = <w> and-or-expr <w '⇒' w> and-or-expr <w>
         <and-or-expr>  = not-expr | and | or
         and            = <w> not-expr <w '∧' w> not-expr <w>
         or             = <w> not-expr <w '∨' w> not-expr <w>

--- a/src/edsger/parsing.cljs
+++ b/src/edsger/parsing.cljs
@@ -15,7 +15,7 @@
         and            = <w> not-expr <w '∧' w> not-expr <w>
         or             = <w> not-expr <w '∨' w> not-expr <w>
         <not-expr>     = statement | not
-        not            = <w '¬' w> statement <w>
+        not            = <w '¬' w> not-expr <w>
         <statement>    = <w> (variable | boolean) <w> | <w '(' w> equiv-expr <w ')' w>
         boolean        = 'true' | 'false'
         variable       = #'[a-zA-Z]'

--- a/src/edsger/parsing.cljs
+++ b/src/edsger/parsing.cljs
@@ -12,8 +12,8 @@
         <implies-expr> = and-or-expr | implies
         implies        = <w> implies-expr <w '⇒' w> and-or-expr <w>
         <and-or-expr>  = not-expr | and | or
-        and            = <w> and-or-expr <w '∧' w> not-expr <w>
-        or             = <w> and-or-expr <w '∨' w> not-expr <w>
+        and            = <w> not-expr <w '∧' w> not-expr <w>
+        or             = <w> not-expr <w '∨' w> not-expr <w>
         <not-expr>     = statement | not
         not            = <w '¬' w> statement <w>
         <statement>    = <w> (variable | boolean) <w> | <w '(' w> equiv-expr <w ')' w>

--- a/src/edsger/parsing.cljs
+++ b/src/edsger/parsing.cljs
@@ -8,7 +8,7 @@
   infix-cfg
   (str "top-level      = equiv-expr
         <equiv-expr>   = implies-expr | equiv
-        equiv          = <w> equiv-expr <w '≡' w> implies-expr <w>
+        equiv          = <w> implies-expr <w '≡' w> implies-expr <w>
         <implies-expr> = and-or-expr | implies
         implies        = <w> implies-expr <w '⇒' w> and-or-expr <w>
         <and-or-expr>  = not-expr | and | or

--- a/test/edsger/parsing_test.cljs
+++ b/test/edsger/parsing_test.cljs
@@ -105,6 +105,17 @@
                         [:or [:variable "t"] [:variable "u"]]]
                        [:and [:not [:variable "w"]] [:variable "x"]]]]])))
 
+(deftest infix-cfg_extraneous-parens-ignored
+  (are [input] (= (p/infix-cfg input) [:top-level [:variable "p"]])
+    "p"
+    "(p)"
+    "(((p)))")
+  (are [input] (= (p/infix-cfg input) [:top-level [:or [:variable "p"] [:variable "q"]]])
+    "p∨q"
+    "(p∨q)"
+    "(p)∨(q)"
+    "(p∨((q)))"))
+
 
 ;; ==== Tests for `transform-infix-cfg`
 

--- a/test/edsger/parsing_test.cljs
+++ b/test/edsger/parsing_test.cljs
@@ -94,6 +94,18 @@
                                        [:implies [:variable "p"] [:variable "q"]]
                                        [:variable "r"]]])))
 
+(deftest infix-cfg_general-precedence
+  (is (= (p/infix-cfg "(p ∧ q) ∨ r ≡ s ∧ (t ∨ u) ⇒ ¬w ∧ x")
+         [:top-level [:equiv
+                      [:or
+                       [:and [:variable "p"] [:variable "q"]]
+                       [:variable "r"]]
+                      [:implies
+                       [:and [:variable "s"]
+                        [:or [:variable "t"] [:variable "u"]]]
+                       [:and [:not [:variable "w"]] [:variable "x"]]]]])))
+
+
 ;; ==== Tests for `transform-infix-cfg`
 
 (deftest transform-infix-cfg_works-with-infix-cfg

--- a/test/edsger/parsing_test.cljs
+++ b/test/edsger/parsing_test.cljs
@@ -74,6 +74,16 @@
                                        [:and [:variable "p"] [:variable "q"]]
                                        [:variable "r"]]])))
 
+(deftest infix-cfg_sequential-equivs
+  (is (= (type (p/infix-cfg "p ≡ q ≡ r")) instaparse.gll/Failure))
+  (is (= (p/infix-cfg "p ≡ (q ≡ r)") [:top-level
+                                      [:equiv [:variable "p"]
+                                       [:equiv [:variable "q"] [:variable "r"]]]]))
+  (is (= (p/infix-cfg "(p ≡ q) ≡ r") [:top-level
+                                      [:equiv
+                                       [:equiv [:variable "p"] [:variable "q"]]
+                                       [:variable "r"]]])))
+
 ;; ==== Tests for `transform-infix-cfg`
 
 (deftest transform-infix-cfg_works-with-infix-cfg

--- a/test/edsger/parsing_test.cljs
+++ b/test/edsger/parsing_test.cljs
@@ -116,6 +116,14 @@
     "(p)∨(q)"
     "(p∨((q)))"))
 
+(deftest infix-cfg_serial-negation
+  (is (= (p/infix-cfg "¬¬¬¬a")
+         [:top-level
+          [:not
+           [:not
+            [:not
+             [:not [:variable "a"]]]]]])))
+
 
 ;; ==== Tests for `transform-infix-cfg`
 

--- a/test/edsger/parsing_test.cljs
+++ b/test/edsger/parsing_test.cljs
@@ -44,6 +44,35 @@
     "¬ true"
     "¬true"))
 
+(deftest infix-cfg_sequential-ands
+  (is (= (type (p/infix-cfg "p ∧ q ∧ r")) instaparse.gll/Failure))
+  (is (= (p/infix-cfg "p ∧ (q ∧ r)") [:top-level
+                                       [:and [:variable "p"]
+                                        [:and [:variable "q"] [:variable "r"]]]]))
+  (is (= (p/infix-cfg "(p ∧ q) ∧ r") [:top-level
+                                        [:and
+                                         [:and [:variable "p"] [:variable "q"]]
+                                         [:variable "r"]]])))
+
+(deftest infix-cfg_sequential-ors
+  (is (= (type (p/infix-cfg "p ∨ q ∨ r")) instaparse.gll/Failure))
+  (is (= (p/infix-cfg "p ∨ (q ∨ r)") [:top-level
+                                       [:or [:variable "p"]
+                                        [:or [:variable "q"] [:variable "r"]]]]))
+  (is (= (p/infix-cfg "(p ∨ q) ∨ r") [:top-level
+                                       [:or
+                                        [:or [:variable "p"] [:variable "q"]]
+                                        [:variable "r"]]])))
+
+(deftest infix-cfg_mixed-and-with-or
+  (is (= (type (p/infix-cfg "p ∧ q ∨ r")) instaparse.gll/Failure))
+  (is (= (p/infix-cfg "p ∧ (q ∨ r)") [:top-level
+                                      [:and [:variable "p"]
+                                       [:or [:variable "q"] [:variable "r"]]]]))
+  (is (= (p/infix-cfg "(p ∧ q) ∨ r") [:top-level
+                                      [:or
+                                       [:and [:variable "p"] [:variable "q"]]
+                                       [:variable "r"]]])))
 
 ;; ==== Tests for `transform-infix-cfg`
 

--- a/test/edsger/parsing_test.cljs
+++ b/test/edsger/parsing_test.cljs
@@ -84,6 +84,16 @@
                                        [:equiv [:variable "p"] [:variable "q"]]
                                        [:variable "r"]]])))
 
+(deftest infix-cfg_sequential-implication
+  (is (= (type (p/infix-cfg "p ⇒ q ⇒ r")) instaparse.gll/Failure))
+  (is (= (p/infix-cfg "p ⇒ (q ⇒ r)") [:top-level
+                                      [:implies [:variable "p"]
+                                       [:implies [:variable "q"] [:variable "r"]]]]))
+  (is (= (p/infix-cfg "(p ⇒ q) ⇒ r") [:top-level
+                                      [:implies
+                                       [:implies [:variable "p"] [:variable "q"]]
+                                       [:variable "r"]]])))
+
 ;; ==== Tests for `transform-infix-cfg`
 
 (deftest transform-infix-cfg_works-with-infix-cfg

--- a/test/edsger/parsing_test.cljs
+++ b/test/edsger/parsing_test.cljs
@@ -15,47 +15,32 @@
 
 (deftest infix-cfg_one-level-operations
   (are [input expected-output] (= (p/infix-cfg input) expected-output)
-    "¬ true" [:top-level [:unary-expr [:unary-op "¬"] [:bottom [:boolean "true"]]]]
-    "a ⇒ false" [:top-level [:binary-expr
-                             [:bottom [:variable "a"]]
-                             [:binary-op "⇒"]
-                             [:bottom [:boolean "false"]]]]
-    "p ≡ q" [:top-level [:binary-expr
-                         [:bottom [:variable "p"]]
-                         [:binary-op "≡"]
-                         [:bottom [:variable "q"]]]]
-    "t ∧ u" [:top-level [:binary-expr
-                         [:bottom [:variable "t"]]
-                         [:binary-op "∧"]
-                         [:bottom [:variable "u"]]]]))
+    "¬ true" [:top-level [:not [:boolean "true"]]]
+    "a ⇒ false" [:top-level [:implies [:variable "a"] [:boolean "false"]]]
+    "p ≡ q" [:top-level [:equiv
+                         [:variable "p"]
+                         [:variable "q"]]]
+    "t ∧ u" [:top-level [:and
+                         [:variable "t"]
+                         [:variable "u"]]]))
 
 (deftest infix-cfg_complex-nexting-with-parens-works
   (is (=
        (p/infix-cfg "(a ⇒ false) ∨ (¬ (t ∧ u))")
-       [:top-level [:binary-expr
-                    [:bottom
-                     [:top-level
-                          [:binary-expr
-                           [:bottom [:variable "a"]]
-                           [:binary-op "⇒"]
-                           [:bottom [:boolean "false"]]]]]
-                    [:binary-op "∨"]
-                    [:bottom
-                     [:top-level
-                          [:unary-expr
-                           [:unary-op "¬"]
-                           [:bottom
-                                [:top-level
-                                 [:binary-expr
-                                  [:bottom [:variable "t"]]
-                                  [:binary-op "∧"]
-                                  [:bottom [:variable "u"]]]]]]]]]])))
+       [:top-level
+        [:or
+         [:implies
+          [:variable "a"]
+          [:boolean "false"]]
+         [:not
+          [:and
+           [:variable "t"]
+           [:variable "u"]]]]])))
 
 (deftest infix-cfg_spaces-with-not
   (are [input] (= (p/infix-cfg input) [:top-level
-                                       [:unary-expr
-                                        [:unary-op "¬"]
-                                        [:bottom [:boolean "true"]]]])
+                                       [:not
+                                        [:boolean "true"]]])
     "¬ true"
     "¬true"))
 


### PR DESCRIPTION
This PR makes the parse have knowledge of precedence between different operators. So it knows that `⇒` binds more tightly than `≡`, but it still doesn't know how do deal with an expression like `p ≡ q ≡ r` since we haven't figured out how to deal with that nicely _after_ parsing. 

Closes #27 (we should make a new issue for series of operators)
Closes #34 (really a duplicate of #27)
Closes #35